### PR TITLE
feat: Add pre-commit and pixi manifest

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+# pixi environments
+.pixi
+*.egg-info
+
+# Ignore lock file
+*.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-added-large-files
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+  - id: codespell

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,20 @@
+[project]
+authors = ["Matthew Feickert <matthew.feickert@cern.ch>"]
+channels = ["conda-forge"]
+name = "scipy-tutorial-proposal-2025"
+platforms = ["linux-64", "osx-64"]
+version = "0.1.0"
+
+[tasks.install]
+description = "Install pre-commit into the Git hooks directory"
+cmd = "pre-commit install"
+
+[tasks.lint]
+description = "Run 'pre-commit run --all-files'"
+cmd = "pre-commit run --all-files"
+
+[tasks.start]
+depends-on = ["install", "lint"]
+
+[dependencies]
+pre-commit = ">=4.1.0"


### PR DESCRIPTION
* Add pre-commit config with codespell.
* Add pixi manifest for linting with pre-commit.
   - Don't add lock file for the time being as for something like pre-commit the reproducibility level concern is low enough for a text only repository.